### PR TITLE
balances alien healing

### DIFF
--- a/code/modules/mob/living/carbon/alien/organs.dm
+++ b/code/modules/mob/living/carbon/alien/organs.dm
@@ -118,13 +118,16 @@
 			if(!isalien(owner))
 				heal_amt *= 0.2
 
-			if (owner.lying)
+			if (owner.lying || affected_by_pheromone || !isalien(owner))
 				var/heal_divider = owner.stat == UNCONSCIOUS ? 2 : 1
 
 				owner.adjustBruteLoss(-heal_amt/heal_divider)
 				owner.adjustFireLoss(-heal_amt/heal_divider)
 				owner.adjustOxyLoss(-heal_amt/heal_divider)
 				owner.adjustCloneLoss(-heal_amt/heal_divider)
+			else
+				if (owner.getBruteLoss() < 50)
+					owner.adjustBruteLoss(-heal_amt)
 
 			owner.adjustPlasma(plasma_rate*multiplier*0.5)
 


### PR DESCRIPTION
- the lying requirement no longer applies to human holders of the plasma vessel organ
- if you're affected by pheromones, you always heal
- if you have minor brute damage, such as by accidentally biting yourself or taking a WEAK shot or two, you heal anyway